### PR TITLE
Fix: Update Cesium CDN links and local relative output paths

### DIFF
--- a/satviz/scripts/visualize_constellation.py
+++ b/satviz/scripts/visualize_constellation.py
@@ -176,11 +176,11 @@ ORB_WISE_IDS[2] = []
 
 
 # General files needed to generate visualizations; Do not change for different simulations
-topFile = "../static_html/top.html"
-bottomFile = "../static_html/bottom.html"
+topFile = "static_html/top.html"
+bottomFile = "static_html/bottom.html"
 
 # Output directory for creating visualization html files
-OUT_DIR = "../viz_output/"
+OUT_DIR = "viz_output/"
 # JSON_NAME  = NAME+"_5shell.json"
 # OUT_JSON_FILE = OUT_DIR + JSON_NAME
 OUT_HTML_FILE = OUT_DIR + NAME + ".html"
@@ -248,5 +248,6 @@ def write_viz_files():
     writer_html.close()
 
 
-viz_string = generate_satelite_trajectories()
+viz_string = generate_satellite_trajectories()
 write_viz_files()
+

--- a/satviz/static_html/top.html
+++ b/satviz/static_html/top.html
@@ -1,8 +1,8 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <script src="https://cesiumjs.org/releases/1.57/Build/Cesium/Cesium.js"></script>
-  <link href="https://cesiumjs.org/releases/1.57/Build/Cesium/Widgets/widgets.css" rel="stylesheet">
+  <link href="https://cesium.com/downloads/cesiumjs/releases/1.118/Build/Cesium/Widgets/widgets.css" rel="stylesheet">
+  <script src="https://cesium.com/downloads/cesiumjs/releases/1.118/Build/Cesium/Cesium.js"></script>
 </head>
 <body>
   <div id="cesiumContainer" style="width: 100%; height:100%"></div>
@@ -38,13 +38,17 @@ var globe = viewer.scene.globe;
 globe.imageryLayers.removeAll();
 globe.baseColor = Cesium.Color.fromCssColorString('#f7fbff');
 
+// var tonerLayer = globe.imageryLayers.addImageryProvider(
+//     Cesium.createOpenStreetMapImageryProvider({
+//         url : 'https://stamen-tiles.a.ssl.fastly.net/toner-background/',
+//         credit : 'Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under CC BY SA.'
+//     })
+// );
 var tonerLayer = globe.imageryLayers.addImageryProvider(
-    Cesium.createOpenStreetMapImageryProvider({
-        url : 'https://stamen-tiles.a.ssl.fastly.net/toner-background/',
-        credit : 'Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under CC BY SA.'
+    new Cesium.OpenStreetMapImageryProvider({
+        url : 'https://a.tile.openstreetmap.org/'
     })
 );
 tonerLayer.alpha = 0.3;
 tonerLayer.brightness = 3;
 tonerLayer.contrast = 0.7;
-


### PR DESCRIPTION
Updated the broken Stamen map layer to OpenStreetMap and fixed the hardcoded relative output paths to prevent FileNotFoundError.